### PR TITLE
Fix tolerance typo

### DIFF
--- a/myFirstScript.cs
+++ b/myFirstScript.cs
@@ -64,14 +64,14 @@ namespace VMS.TPS
             MessageBox.Show(nStructures.ToString() + " structures and " + nNonEmpty.ToString() + " are non empty");
             #endregion
 
-            #region table of tolérance
+            #region table of tolerance
             string tolTable = "";
             foreach (Beam f in context.PlanSetup.Beams)
             {
                 if (!f.IsSetupField)
                 {
                     tolTable = f.ToleranceTableLabel.ToUpper();
-                    MessageBox.Show("table of tolérance of " + f.Id + " : " + tolTable);
+                    MessageBox.Show("table of tolerance of " + f.Id + " : " + tolTable);
                     break;
                 }
             }


### PR DESCRIPTION
## Summary
- fix tolerance spelling in region and message

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0148cba5c832cb3563c8beed19489